### PR TITLE
(#48) Mojo was not annotated

### DIFF
--- a/src/main/java/org/llorllale/mvn/plgn/loggit/Changelog.java
+++ b/src/main/java/org/llorllale/mvn/plgn/loggit/Changelog.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.cactoos.io.InputOf;
 import org.cactoos.io.LengthOf;
@@ -32,12 +33,13 @@ import org.eclipse.jgit.lib.Constants;
 import org.llorllale.mvn.plgn.loggit.xsl.Identity;
 
 /**
- * Loggit.
+ * Changelog.
  *
  * @author George Aristy (george.aristy@gmail.com)
  * @since 0.2.0
  */
-public final class Loggit extends AbstractMojo {
+@Mojo(name = "changelog")
+public final class Changelog extends AbstractMojo {
   @Parameter(name = "repo", defaultValue = "${basedir}")
   private File repo;
 
@@ -49,7 +51,7 @@ public final class Loggit extends AbstractMojo {
    * 
    * @since 0.2.0
    */
-  public Loggit() {
+  public Changelog() {
     //intentional
   }
 
@@ -60,7 +62,7 @@ public final class Loggit extends AbstractMojo {
    * @param output file to which to save the XML
    * @since 0.2.0
    */
-  public Loggit(File repo, File output) {
+  public Changelog(File repo, File output) {
     this.repo = repo;
     this.xml = output;
   }

--- a/src/test/java/org/llorllale/mvn/plgn/loggit/ChangelogTest.java
+++ b/src/test/java/org/llorllale/mvn/plgn/loggit/ChangelogTest.java
@@ -30,13 +30,13 @@ import org.eclipse.jgit.revwalk.RevCommit;
 import org.junit.Test;
 
 /**
- * Tests for {@link Loggit}.
+ * Tests for {@link Changelog}.
  *
  * @author George Aristy (george.aristy@gmail.com)
  * @since 0.2.0
  */
 @SuppressWarnings({"checkstyle:MethodName", "checkstyle:MultipleStringLiterals"})
-public final class LoggitTest {
+public final class ChangelogTest {
   /**
    * Writes git log to XML. The file should have all entries from the git log.
    * 
@@ -49,7 +49,7 @@ public final class LoggitTest {
     final RevCommit first = this.addCommit(repo, "first", "first@test.com", "First commit");
     final RevCommit second = this.addCommit(repo, "second", "second@test.com", "Second commit");
     final File output = repo.getRepository().getWorkTree().toPath().resolve("log.xml").toFile();
-    new Loggit(
+    new Changelog(
       repo.getRepository().getWorkTree(),
       output
     ).execute();
@@ -77,7 +77,7 @@ public final class LoggitTest {
    */
   @Test(expected = MojoFailureException.class)
   public void failsWithInvalidPathToRepo() throws Exception {
-    new Loggit(Files.createTempDirectory("").toFile(), new File("log.xml")).execute();
+    new Changelog(Files.createTempDirectory("").toFile(), new File("log.xml")).execute();
   }
 
   /**
@@ -90,7 +90,7 @@ public final class LoggitTest {
   public void failsWithInvalidPathToOutputXml() throws Exception {
     final File dir = Files.createTempDirectory("").toFile();
     final File xml = Files.createTempDirectory("").toFile();
-    new Loggit(dir, xml).execute();
+    new Changelog(dir, xml).execute();
   }
 
   /**


### PR DESCRIPTION
closes #48 

This PR:
* Renames `Loggit` -> `Changelog` (test class was similarly renamed)
* Annotated `Changelog` with `@Mojo(name = 'changelog')`