### PR TITLE
(#47) Implement the markdown transform

### DIFF
--- a/src/main/java/org/llorllale/mvn/plgn/loggit/Changelog.java
+++ b/src/main/java/org/llorllale/mvn/plgn/loggit/Changelog.java
@@ -38,6 +38,9 @@ import org.llorllale.mvn.plgn.loggit.xsl.Markdown;
  *
  * @author George Aristy (george.aristy@gmail.com)
  * @since 0.2.0
+ * @todo #47:30min Implement some way to accept custom transformation files. The default
+ *  markdown transformation may not suit everyone. Things like date formats and other
+ *  stuff can go there.
  */
 @Mojo(name = "changelog")
 public final class Changelog extends AbstractMojo {

--- a/src/main/java/org/llorllale/mvn/plgn/loggit/Changelog.java
+++ b/src/main/java/org/llorllale/mvn/plgn/loggit/Changelog.java
@@ -31,6 +31,7 @@ import org.cactoos.io.TeeInput;
 import org.cactoos.scalar.IoCheckedScalar;
 import org.eclipse.jgit.lib.Constants;
 import org.llorllale.mvn.plgn.loggit.xsl.Identity;
+import org.llorllale.mvn.plgn.loggit.xsl.Markdown;
 
 /**
  * Changelog.
@@ -45,6 +46,9 @@ public final class Changelog extends AbstractMojo {
 
   @Parameter(name = "outputFile", defaultValue = "gitlog.xml")
   private File xml;
+
+  @Parameter(name = "format", defaultValue = "default")
+  private String format;
 
   /**
    * Ctor.
@@ -63,8 +67,21 @@ public final class Changelog extends AbstractMojo {
    * @since 0.2.0
    */
   public Changelog(File repo, File output) {
+    this(repo, output, "default");
+  }
+
+  /**
+   * Ctor.
+   * 
+   * @param repo path to git repo
+   * @param output file to which to save the XML
+   * @param format the format for the output
+   * @since 0.2.0
+   */
+  public Changelog(File repo, File output, String format) {
     this.repo = repo;
     this.xml = output;
+    this.format = format;
   }
 
   @Override
@@ -98,6 +115,15 @@ public final class Changelog extends AbstractMojo {
    * @throws IOException if there's an issue reading the stylesheet
    */
   private String transform(XML original) throws IOException {
-    return new Identity().applyTo(original);
+    final String output;
+    switch (this.format) {
+      case "markdown":
+        output = new Markdown().applyTo(original);
+        break;
+      default:
+        output = new Identity().applyTo(original);
+        break;
+    }
+    return output;
   }
 }

--- a/src/main/java/org/llorllale/mvn/plgn/loggit/Changelog.java
+++ b/src/main/java/org/llorllale/mvn/plgn/loggit/Changelog.java
@@ -33,14 +33,14 @@ import org.eclipse.jgit.lib.Constants;
 import org.llorllale.mvn.plgn.loggit.xsl.Identity;
 import org.llorllale.mvn.plgn.loggit.xsl.Markdown;
 
+// @todo #47:30min Implement some way to accept custom transformation files. The default
+//  markdown transformation may not suit everyone. Things like date formats and other
+//  stuff can go there.
 /**
  * Changelog.
  *
  * @author George Aristy (george.aristy@gmail.com)
  * @since 0.2.0
- * @todo #47:30min Implement some way to accept custom transformation files. The default
- *  markdown transformation may not suit everyone. Things like date formats and other
- *  stuff can go there.
  */
 @Mojo(name = "changelog")
 public final class Changelog extends AbstractMojo {
@@ -119,13 +119,10 @@ public final class Changelog extends AbstractMojo {
    */
   private String transform(XML original) throws IOException {
     final String output;
-    switch (this.format) {
-      case "markdown":
-        output = new Markdown().applyTo(original);
-        break;
-      default:
-        output = new Identity().applyTo(original);
-        break;
+    if ("markdown".equals(this.format)) {
+      output = new Markdown().applyTo(original);
+    } else {
+      output = new Identity().applyTo(original);
     }
     return output;
   }

--- a/src/main/java/org/llorllale/mvn/plgn/loggit/xsl/Markdown.java
+++ b/src/main/java/org/llorllale/mvn/plgn/loggit/xsl/Markdown.java
@@ -16,37 +16,19 @@
 
 package org.llorllale.mvn.plgn.loggit.xsl;
 
-// @checkstyle AvoidStaticImport (2 lines)
-import static com.jcabi.matchers.XhtmlMatchers.hasXPaths;
-import static org.junit.Assert.assertThat;
-
-import com.jcabi.xml.XMLDocument;
-import org.junit.Test;
-
 /**
- * Tests for {@link Identity}.
+ * Default markdown transformation.
  *
  * @author George Aristy (george.aristy@gmail.com)
  * @since 0.2.0
  */
-@SuppressWarnings("checkstyle:MethodName")
-public final class IdentityTest {
+public final class Markdown extends StylesheetEnvelope {
   /**
-   * Output must be the same as input.
+   * Ctor.
    * 
    * @since 0.2.0
    */
-  @Test
-  public void noChangesToXml() {
-    assertThat(
-      new Identity().transform(
-        new XMLDocument("<doc><id>1</id><author>George</author><email>email@test.com</email></doc>")
-      ),
-      hasXPaths(
-        "/doc[id = 1]",
-        "/doc[author = 'George']",
-        "/doc[email = 'email@test.com']"
-      )
-    );
+  public Markdown() {
+    super("/xsl/markdown.xsl");
   }
 }

--- a/src/main/resources/xsl/markdown.xsl
+++ b/src/main/resources/xsl/markdown.xsl
@@ -18,11 +18,10 @@
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
   <xsl:output method="text"/>
-  <xsl:template match="log">
-    # CHANGELOG
-    <xsl:for-each select="commits/commit">
-      * id: <xsl:value-of select="id"/> (by <xsl:value-of select="author/name"/>)
-        <xsl:value-of select="message/short"/>
+  <xsl:variable name="newLine"><xsl:text>&#xa;</xsl:text></xsl:variable>
+  <xsl:template match="log"># CHANGELOG<xsl:for-each select="commits/commit"><xsl:value-of select="$newLine"/>* id: <xsl:value-of select="substring(id, 1, 7)"/> (by <xsl:value-of select="author/name"/>)
+      <xsl:value-of select="message/short"/> 
     </xsl:for-each>
+    <xsl:value-of select="$newLine"/>
   </xsl:template>
 </xsl:stylesheet>

--- a/src/test/java/org/llorllale/mvn/plgn/loggit/ChangelogTest.java
+++ b/src/test/java/org/llorllale/mvn/plgn/loggit/ChangelogTest.java
@@ -16,8 +16,9 @@
 
 package org.llorllale.mvn.plgn.loggit;
 
-// @checkstyle AvoidStaticImport (2 lines)
+// @checkstyle AvoidStaticImport (3 lines)
 import static com.jcabi.matchers.XhtmlMatchers.hasXPaths;
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertThat;
 
 import java.io.File;
@@ -91,6 +92,28 @@ public final class ChangelogTest {
     final File dir = Files.createTempDirectory("").toFile();
     final File xml = Files.createTempDirectory("").toFile();
     new Changelog(dir, xml).execute();
+  }
+
+  /**
+   * Must output to default markdown format if "markdown" is the given format.
+   * 
+   * @throws Exception unexpected
+   * @since 0.2.0
+   */
+  @Test
+  public void defaultMarkdownOutput() throws Exception {
+    final org.eclipse.jgit.api.Git repo = this.repo();
+    this.addCommit(repo, "first", "first@test.com", "First commit");
+    this.addCommit(repo, "second", "second@test.com", "Second commit");
+    final File output = repo.getRepository().getWorkTree().toPath().resolve("log.xml").toFile();
+    new Changelog(
+      repo.getRepository().getWorkTree(),
+      output, "markdown"
+    ).execute();
+    assertThat(
+      new TextOf(output).asString(),
+      startsWith("# CHANGELOG")
+    );
   }
 
   /**

--- a/src/test/java/org/llorllale/mvn/plgn/loggit/xsl/MarkdownTest.java
+++ b/src/test/java/org/llorllale/mvn/plgn/loggit/xsl/MarkdownTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2018 George Aristy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.llorllale.mvn.plgn.loggit.xsl;
+
+// @checkstyle AvoidStaticImport (2 lines)
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import com.jcabi.xml.XMLDocument;
+import org.junit.Test;
+
+/**
+ * Tests for {@link Markdown}.
+ *
+ * @author George Aristy (george.aristy@gmail.com)
+ * @since 0.2.0
+ */
+@SuppressWarnings("checkstyle:MultipleStringLiterals")
+public final class MarkdownTest {
+  private static final String LOG =
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+    + "<log>"
+    + "  <commits>"
+    + "    <commit>"
+    + "      <id>fcc814a658aea3537ad5182ff211ed8c58479fb9</id>"
+    + "      <author>"
+    + "        <name>second</name>"
+    + "        <email>second@test.com</email>"
+    + "        <date>2018-02-26T16:42:00Z</date>"
+    + "      </author>"
+    + "      <message>"
+    + "        <short>Second commit</short>"
+    + "        <full>Second commit</full>"
+    + "      </message>"
+    + "    </commit>"
+    + "    <commit>"
+    + "      <id>b8ed3b64435525f8f5c9196489dce85613cefe96</id>"
+    + "      <author>"
+    + "        <name>first</name>"
+    + "        <email>first@test.com</email>"
+    + "        <date>2018-02-26T16:42:00Z</date>"
+    + "      </author>"
+    + "      <message>"
+    + "        <short>First commit</short>"
+    + "        <full>First commit</full>"
+    + "      </message>"
+    + "    </commit>"
+    + "  </commits>"
+    + "</log>";
+
+  /**
+   * Default markdown format.
+   * 
+   * @since 0.2.0
+   */
+  @Test
+  public void defaultMarkdown() {
+    assertThat(
+      new Markdown().applyTo(new XMLDocument(MarkdownTest.LOG)).replaceAll("\\r\\n", "\n"),
+      // @checkstyle LineLength (1 line)
+      is(
+        "# CHANGELOG\n"
+        + "* id: fcc814a (by second)\n"
+        + "      Second commit\n"
+        + "* id: b8ed3b6 (by first)\n"
+        + "      First commit\n"
+      )
+    );
+  }
+}


### PR DESCRIPTION
closes #47 

This PR:
* Implements a default markdown output transformation
* Introduces the `format` mojo property to indicate the desired output format. Default is `default` in which case the `identity.xsl` will be used
* Creates new puzzle for adding custom transformations