### PR TITLE
(#55) Custom transformations

### DIFF
--- a/src/main/java/org/llorllale/mvn/plgn/loggit/Changelog.java
+++ b/src/main/java/org/llorllale/mvn/plgn/loggit/Changelog.java
@@ -30,12 +30,10 @@ import org.cactoos.io.OutputTo;
 import org.cactoos.io.TeeInput;
 import org.cactoos.scalar.IoCheckedScalar;
 import org.eclipse.jgit.lib.Constants;
+import org.llorllale.mvn.plgn.loggit.xsl.Custom;
 import org.llorllale.mvn.plgn.loggit.xsl.Identity;
 import org.llorllale.mvn.plgn.loggit.xsl.Markdown;
 
-// @todo #47:30min Implement some way to accept custom transformation files. The default
-//  markdown transformation may not suit everyone. Things like date formats and other
-//  stuff can go there.
 /**
  * Changelog.
  *
@@ -52,6 +50,9 @@ public final class Changelog extends AbstractMojo {
 
   @Parameter(name = "format", defaultValue = "default")
   private String format;
+
+  @Parameter(name = "customFormatFile")
+  private File customFormat;
 
   /**
    * Ctor.
@@ -82,9 +83,23 @@ public final class Changelog extends AbstractMojo {
    * @since 0.2.0
    */
   public Changelog(File repo, File output, String format) {
+    this(repo, output, format, null);
+  }
+
+  /**
+   * Ctor.
+   * 
+   * @param repo path to git repo
+   * @param output file to which to save the XML
+   * @param format the format for the output
+   * @param customFormat path to customFormat
+   * @since 0.2.0
+   */
+  public Changelog(File repo, File output, String format, File customFormat) {
     this.repo = repo;
     this.xml = output;
     this.format = format;
+    this.customFormat = customFormat;
   }
 
   @Override
@@ -121,6 +136,8 @@ public final class Changelog extends AbstractMojo {
     final String output;
     if ("markdown".equals(this.format)) {
       output = new Markdown().applyTo(original);
+    } else if ("custom".equals(this.format)) {
+      output = new Custom(new InputOf(this.customFormat)).applyTo(original);
     } else {
       output = new Identity().applyTo(original);
     }

--- a/src/main/java/org/llorllale/mvn/plgn/loggit/xsl/Custom.java
+++ b/src/main/java/org/llorllale/mvn/plgn/loggit/xsl/Custom.java
@@ -16,21 +16,22 @@
 
 package org.llorllale.mvn.plgn.loggit.xsl;
 
-import org.cactoos.io.ResourceOf;
+import org.cactoos.Input;
 
 /**
- * Creates an identical copy of the XML.
+ * Custom XSLT provided by the user.
  *
  * @author George Aristy (george.aristy@gmail.com)
  * @since 0.2.0
  */
-public final class Identity extends StylesheetEnvelope {
+public final class Custom extends StylesheetEnvelope {
   /**
    * Ctor.
    * 
+   * @param custom the custom XSLT
    * @since 0.2.0
    */
-  public Identity() {
-    super(new ResourceOf("xsl/identity.xsl"));
+  public Custom(Input custom) {
+    super(custom);
   }
 }

--- a/src/main/java/org/llorllale/mvn/plgn/loggit/xsl/Markdown.java
+++ b/src/main/java/org/llorllale/mvn/plgn/loggit/xsl/Markdown.java
@@ -16,6 +16,8 @@
 
 package org.llorllale.mvn.plgn.loggit.xsl;
 
+import org.cactoos.io.ResourceOf;
+
 /**
  * Default markdown transformation.
  *
@@ -29,6 +31,6 @@ public final class Markdown extends StylesheetEnvelope {
    * @since 0.2.0
    */
   public Markdown() {
-    super("/xsl/markdown.xsl");
+    super(new ResourceOf("xsl/markdown.xsl"));
   }
 }

--- a/src/main/java/org/llorllale/mvn/plgn/loggit/xsl/StylesheetEnvelope.java
+++ b/src/main/java/org/llorllale/mvn/plgn/loggit/xsl/StylesheetEnvelope.java
@@ -20,6 +20,7 @@ import com.jcabi.xml.Sources;
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XSL;
 import com.jcabi.xml.XSLDocument;
+import org.cactoos.Input;
 import org.cactoos.scalar.StickyScalar;
 import org.cactoos.scalar.UncheckedScalar;
 
@@ -35,13 +36,13 @@ abstract class StylesheetEnvelope implements XSL {
   /**
    * Ctor.
    * 
-   * @param file path to the XSL file
+   * @param input the XSL file
    * @since 0.2.0
    */
-  StylesheetEnvelope(String file) {
+  StylesheetEnvelope(Input input) {
     this.stylesheet = new UncheckedScalar<>(
       new StickyScalar<>(
-        () -> new XSLDocument(this.getClass().getResourceAsStream(file))
+        () -> new XSLDocument(input.stream())
       )
     );
   }

--- a/src/test/java/org/llorllale/mvn/plgn/loggit/ChangelogTest.java
+++ b/src/test/java/org/llorllale/mvn/plgn/loggit/ChangelogTest.java
@@ -16,8 +16,9 @@
 
 package org.llorllale.mvn.plgn.loggit;
 
-// @checkstyle AvoidStaticImport (3 lines)
+// @checkstyle AvoidStaticImport (4 lines)
 import static com.jcabi.matchers.XhtmlMatchers.hasXPaths;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertThat;
 
@@ -113,6 +114,29 @@ public final class ChangelogTest {
     assertThat(
       new TextOf(output).asString(),
       startsWith("# CHANGELOG")
+    );
+  }
+
+  /**
+   * Uses custom transformation.
+   * 
+   * @throws Exception unexpected
+   * @since 0.2.0
+   */
+  @Test
+  public void customOutput() throws Exception {
+    final org.eclipse.jgit.api.Git repo = this.repo();
+    this.addCommit(repo, "first", "first@test.com", "First commit");
+    this.addCommit(repo, "second", "second@test.com", "Second commit");
+    final File output = repo.getRepository().getWorkTree().toPath().resolve("log.xml").toFile();
+    new Changelog(
+      repo.getRepository().getWorkTree(),
+      output, "custom",
+      new File("src/test/resources/org/llorllale/mvn/plgn/loggit/changelogtest.xsl")
+    ).execute();
+    assertThat(
+      new TextOf(output).asString(),
+      containsString("second,first")
     );
   }
 

--- a/src/test/java/org/llorllale/mvn/plgn/loggit/xsl/CustomTest.java
+++ b/src/test/java/org/llorllale/mvn/plgn/loggit/xsl/CustomTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018 George Aristy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.llorllale.mvn.plgn.loggit.xsl;
+
+// @checkstyle AvoidStaticImport (2 lines)
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+
+import com.jcabi.xml.XMLDocument;
+import org.cactoos.io.InputOf;
+import org.junit.Test;
+
+/**
+ * Tests for {@link Custom}.
+ *
+ * @author George Aristy (george.aristy@gmail.com)
+ * @since 0.2.0
+ */
+@SuppressWarnings("checkstyle:MultipleStringLiterals")
+public final class CustomTest {
+  private static final String LOG =
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+    + "<log>"
+    + "  <commits>"
+    + "    <commit>"
+    + "      <id>fcc814a658aea3537ad5182ff211ed8c58479fb9</id>"
+    + "      <author>"
+    + "        <name>second</name>"
+    + "        <email>second@test.com</email>"
+    + "        <date>2018-02-26T16:42:00Z</date>"
+    + "      </author>"
+    + "      <message>"
+    + "        <short>Second commit</short>"
+    + "        <full>Second commit</full>"
+    + "      </message>"
+    + "    </commit>"
+    + "    <commit>"
+    + "      <id>b8ed3b64435525f8f5c9196489dce85613cefe96</id>"
+    + "      <author>"
+    + "        <name>first</name>"
+    + "        <email>first@test.com</email>"
+    + "        <date>2018-02-26T16:42:00Z</date>"
+    + "      </author>"
+    + "      <message>"
+    + "        <short>First commit</short>"
+    + "        <full>First commit</full>"
+    + "      </message>"
+    + "    </commit>"
+    + "  </commits>"
+    + "</log>";
+
+  /**
+   * Applies any custom XSLT provided.
+   * 
+   * @since 0.2.0
+   */
+  @Test
+  public void appliesCustomXslt() {
+    assertThat(
+      new Custom(new InputOf(
+        "<xsl:stylesheet xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\" version=\"2.0\">"
+        + "  <xsl:output method=\"text\"/>"
+        + "  <xsl:template match=\"commits\">"
+        + "    <xsl:for-each select=\"commit\"><xsl:value-of select=\"id\"/>,</xsl:for-each>"
+        + "  </xsl:template>"
+        + "</xsl:stylesheet>"
+      )).applyTo(new XMLDocument(CustomTest.LOG)),
+      containsString(
+        "fcc814a658aea3537ad5182ff211ed8c58479fb9,b8ed3b64435525f8f5c9196489dce85613cefe96,"
+      )
+    );
+  }
+}

--- a/src/test/resources/org/llorllale/mvn/plgn/loggit/changelogtest.xsl
+++ b/src/test/resources/org/llorllale/mvn/plgn/loggit/changelogtest.xsl
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<!--
+
+    Copyright 2018 George Aristy
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+  <xsl:output method="text"/>
+  <xsl:template match="commits">
+    <xsl:for-each select="//author"><xsl:value-of select="name"/>,</xsl:for-each>
+  </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
closes #55 

This PR:

* Creates new parameter `customFormatFile` to be specified when `format` is set to "custom"
* Creates new `Custom` XSLT that accepts `customFormatFile` 
* Refactors `StyleSheetEnvelope` so that it can be reused with files not in the classpath