### PR TITLE
(#57) Build job for tags not being triggered

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,16 @@ jdk:
 jobs:
   include:
   - if: type = pull_request
-    script: mvn -P release-profile -DskipTests=true clean install && \
-            mvn clean cobertura:cobertura && \
-            mvn -DskipTests=true cobertura:check && \
+    script: mvn -P release-profile -DskipTests=true clean install && 
+            mvn clean cobertura:cobertura && 
+            mvn -DskipTests=true cobertura:check && 
             bash <(curl -s https://codecov.io/bash)
   - if: type = push AND branch = master
-    script: mvn -P release-profile -DskipTests=true clean install && \
-            mvn clean cobertura:cobertura && \
-            mvn -DskipTests=true cobertura:check && \
-            bash <(curl -s https://codecov.io/bash) && \
-            ./release/deploy.sh && \
+    script: mvn -P release-profile -DskipTests=true clean install && 
+            mvn clean cobertura:cobertura && 
+            mvn -DskipTests=true cobertura:check && 
+            bash <(curl -s https://codecov.io/bash) && 
+            ./release/deploy.sh && 
             mvn -P site clean compile site
     deploy:
       provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,39 +9,17 @@ jdk:
 jobs:
   include:
   - if: type = pull_request
-    script:
-    - mvn -P release-profile -DskipTests=true clean install
-    - mvn clean cobertura:cobertura && mvn -DskipTests=true cobertura:check
-    - bash <(curl -s https://codecov.io/bash)
-  - if: type = push AND tag IS present AND branch = master
-    script:
-    - openssl aes-256-cbc -K $encrypted_ed9a8466a19c_key -iv $encrypted_ed9a8466a19c_iv
-      -in release/codesigning.asc.enc -out release/codesigning.asc -d
-    - gpg --fast-import release/codesigning.asc
-    - mvn versions:set -DnewVersion=$TRAVIS_TAG && mvn --settings release/mvnsettings.xml -P deploy -DskipTests=true clean deploy
-    - mvn --settings release/mvnsettings.xml -P deploy -DskipTests=true clean deploy
-    - mvn -P site clean compile site
-    deploy:
-      provider: pages
-      skip_cleanup: true
-      local_dir: target/site/
-      github_token: "$site_token"
-      on:
-        tags: true
-        branch: master
-  - if: type = push AND NOT tag IS present AND branch = master
-    script:
-    - mvn clean cobertura:cobertura && mvn -DskipTests=true cobertura:check
-    - bash <(curl -s https://codecov.io/bash)
-    - mvn -P release-profile -DskipTests=true clean install
-    - openssl aes-256-cbc -K $encrypted_ed9a8466a19c_key -iv $encrypted_ed9a8466a19c_iv
-      -in release/codesigning.asc.enc -out release/codesigning.asc -d
-    - gpg --fast-import release/codesigning.asc
-    - . ./release/rc_version.sh
-    - export VERSION=$(mvn help:evaluate -Dexpression=project.version | grep '^[0-9]' | sed "s/SNAPSHOT/rc$RC_VERSION/")
-    - echo "Candidate Version is $VERSION"
-    - mvn versions:set -DnewVersion=$VERSION && mvn --settings release/mvnsettings.xml -P deploy -DskipTests=true clean deploy
-    - mvn -P site clean compile site
+    script: mvn -P release-profile -DskipTests=true clean install && \
+            mvn clean cobertura:cobertura && \
+            mvn -DskipTests=true cobertura:check && \
+            bash <(curl -s https://codecov.io/bash)
+  - if: type = push AND branch = master
+    script: mvn -P release-profile -DskipTests=true clean install && \
+            mvn clean cobertura:cobertura && \
+            mvn -DskipTests=true cobertura:check && \
+            bash <(curl -s https://codecov.io/bash) && \
+            ./release/deploy.sh && \
+            mvn -P site clean compile site
     deploy:
       provider: pages
       skip_cleanup: true

--- a/release/deploy.sh
+++ b/release/deploy.sh
@@ -1,0 +1,69 @@
+#
+# Copyright 2018 George Aristy
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+# Deploys binaries for full and candidate releases
+
+POM=../pom.xml
+MVN="mvn -f $POM"
+
+# Version currently set in the POM
+project_version()
+{
+  echo $($MVN help:evaluate -Dexpression=project.version | grep "^[0-9]")
+}
+
+# A candidate version calculated based on the current POM version and the number
+# of commits since the last git tag
+release_candidate_version()
+{
+  DESCRIBE=$(git describe)
+
+  if [ -z "$DESCRIBE" ]; then
+    RC_VERSION=$(git rev-list --count HEAD)
+  else
+    RC_VERSION=$(echo $DESCRIBE | cut -d - -f 2)
+  fi
+
+  actual=$(project_version)
+  echo $(echo $actual | sed "s/SNAPSHOT/rc$RC_VERSION/")
+}
+
+# If the current POM version is a SNAPSHOT
+is_snapshot()
+{
+  actual=$(project_version)
+  [[ $actual =~ ^.*SNAPSHOT$ ]] && echo 1 || echo 0
+}
+
+project_version=$(project_version)
+is_snapshot=$(is_snapshot)
+
+if [ $is_snapshot ]; then
+  release_version=$(release_candidate_version)
+  $MVN versions:set -DnewVersion=$release_version > /dev/null
+else
+  release_version=$project_version
+fi
+
+echo project version: $project_version
+echo is snapshot: $is_snapshot
+echo release version: $release_version
+
+openssl aes-256-cbc -K $encrypted_ed9a8466a19c_key -iv $encrypted_ed9a8466a19c_iv -in codesigning.asc.enc -out codesigning.asc -d
+gpg --fast-import codesigning.asc
+$MVN --settings mvnsettings.xml -P deploy -DskipTests=true clean deploy
+


### PR DESCRIPTION
closes #57 

This PR:
* introduces `deploy.sh` script to handle deployment of binaries to maven central. It handles the versioning of the POM
* coalesces the "push to master without tag" and "push to master with tag" jobs into one in the travis build.
