### PR TITLE
(#38) IOException if branch does not exist

### DIFF
--- a/src/main/java/org/llorllale/mvn/plgn/loggit/DefaultGit.java
+++ b/src/main/java/org/llorllale/mvn/plgn/loggit/DefaultGit.java
@@ -46,7 +46,7 @@ final class DefaultGit implements Git {
     final Repository repo = new FileRepository(this.path.toFile());
     return new DefaultLog(
       repo,
-      repo.findRef(Constants.MASTER)
+      () -> repo.findRef(Constants.MASTER)
     );
   }
 }

--- a/src/main/java/org/llorllale/mvn/plgn/loggit/DefaultLog.java
+++ b/src/main/java/org/llorllale/mvn/plgn/loggit/DefaultLog.java
@@ -20,8 +20,9 @@ import com.jcabi.xml.StrictXML;
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
 import java.io.IOException;
-import java.util.Objects;
+import org.cactoos.Scalar;
 import org.cactoos.iterable.Mapped;
+import org.cactoos.scalar.IoCheckedScalar;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevWalk;
@@ -36,7 +37,7 @@ import org.xembly.Xembler;
  */
 final class DefaultLog implements Log {
   private final Repository repo;
-  private final Ref ref;
+  private final IoCheckedScalar<Ref> ref;
 
   /**
    * Ctor.
@@ -45,9 +46,9 @@ final class DefaultLog implements Log {
    * @param ref the ref for which to get the commits for
    * @since 0.1.0
    */
-  DefaultLog(Repository repo, Ref ref) {
+  DefaultLog(Repository repo, Scalar<Ref> ref) {
     this.repo = repo;
-    this.ref = ref;
+    this.ref = new IoCheckedScalar<>(ref);
   }
 
   @Override
@@ -56,7 +57,7 @@ final class DefaultLog implements Log {
       final RevWalk walk = new RevWalk(this.repo);
       walk.markStart(
         walk.parseCommit(
-          Objects.requireNonNull(this.ref, "null ref!").getObjectId()
+          this.ref.value().getObjectId()
         )
       );
       return new Mapped<>(

--- a/src/main/resources/xsd/schema.xsd
+++ b/src/main/resources/xsd/schema.xsd
@@ -23,7 +23,7 @@
       <xsd:element name="commits">
         <xsd:complexType>
           <xsd:sequence>
-            <xsd:element ref="commit" minOccurs="0" maxOccurs="unbounded"/>
+            <xsd:element ref="commit" maxOccurs="unbounded"/>
           </xsd:sequence>
         </xsd:complexType>
       </xsd:element>


### PR DESCRIPTION
closes #38 

This PR:
* Makes `DefaultLog.commits()` throw an `IOException` if the given ref does not exist. Since the given `Ref` is supposed to point to a branch, this means that the given branch does not exist. Therefore, a branch cannot truly exist without commits.
* Based on the above, the model was tweaked so that at least one commit is expected in the report.