### PR TITLE
(#59) User can now specify ref from which to generate log

### DIFF
--- a/src/main/java/org/llorllale/mvn/plgn/loggit/Changelog.java
+++ b/src/main/java/org/llorllale/mvn/plgn/loggit/Changelog.java
@@ -54,6 +54,9 @@ public final class Changelog extends AbstractMojo {
   @Parameter(name = "customFormatFile")
   private File customFormat;
 
+  @Parameter(name = "ref", defaultValue = Constants.MASTER)
+  private String ref;
+
   /**
    * Ctor.
    * 
@@ -96,10 +99,26 @@ public final class Changelog extends AbstractMojo {
    * @since 0.2.0
    */
   public Changelog(File repo, File output, String format, File customFormat) {
+    this(repo, output, format, customFormat, Constants.MASTER);
+  }
+
+  /**
+   * Ctor.
+   * 
+   * @param repo path to git repo
+   * @param output file to which to save the XML
+   * @param format the format for the output
+   * @param customFormat path to customFormat
+   * @param ref the ref to point to in order to fetch the log
+   * @since 0.3.0
+   */
+  @SuppressWarnings("checkstyle:ParameterNumber")
+  public Changelog(File repo, File output, String format, File customFormat, String ref) {
     this.repo = repo;
     this.xml = output;
     this.format = format;
     this.customFormat = customFormat;
+    this.ref = ref;
   }
 
   @Override
@@ -110,7 +129,9 @@ public final class Changelog extends AbstractMojo {
           new TeeInput(
             new InputOf(
               this.transform(
-                new DefaultGit(this.repo.toPath().resolve(Constants.DOT_GIT)).log().asXml()
+                new DefaultGit(
+                  this.repo.toPath().resolve(Constants.DOT_GIT), this.ref
+                ).log().asXml()
               )
             ),
             new OutputTo(this.xml)

--- a/src/main/java/org/llorllale/mvn/plgn/loggit/DefaultGit.java
+++ b/src/main/java/org/llorllale/mvn/plgn/loggit/DefaultGit.java
@@ -19,7 +19,6 @@ package org.llorllale.mvn.plgn.loggit;
 import java.io.IOException;
 import java.nio.file.Path;
 import org.eclipse.jgit.internal.storage.file.FileRepository;
-import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.Repository;
 
 /**
@@ -30,15 +29,18 @@ import org.eclipse.jgit.lib.Repository;
  */
 final class DefaultGit implements Git {
   private final Path path;
+  private final String ref;
 
   /**
    * Ctor.
    * 
    * @param path path to the repo's dir
-   * @since 0.1.0
+   * @param ref the ref to point to in order to fetch the log
+   * @since 0.3.0
    */
-  DefaultGit(Path path) {
+  DefaultGit(Path path, String ref) {
     this.path = path;
+    this.ref = ref;
   }
 
   @Override
@@ -46,7 +48,7 @@ final class DefaultGit implements Git {
     final Repository repo = new FileRepository(this.path.toFile());
     return new DefaultLog(
       repo,
-      () -> repo.findRef(Constants.MASTER)
+      () -> repo.findRef(this.ref)
     );
   }
 }

--- a/src/test/java/org/llorllale/mvn/plgn/loggit/DefaultGitTest.java
+++ b/src/test/java/org/llorllale/mvn/plgn/loggit/DefaultGitTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertNotNull;
 
 import java.io.IOException;
 import java.nio.file.Paths;
+import org.eclipse.jgit.lib.Constants;
 import org.junit.Test;
 
 /**
@@ -40,7 +41,7 @@ public final class DefaultGitTest {
   @Test
   public void logIsNotNull() throws IOException {
     assertNotNull(
-      new DefaultGit(Paths.get(".")).log()
+      new DefaultGit(Paths.get("."), Constants.MASTER).log()
     );
   }
 }


### PR DESCRIPTION
closes #59 

This PR:
* Enables the user to specify the git ref from which the user desires to generate the log. This ref can point to any [commitish](https://stackoverflow.com/a/23303550/1623885). This includes things like specific commit IDs, or branch names. `master` remains the default ref.