### PR TITLE
(#65) Mojo fails with "Cannot find 'outputFile'"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -460,7 +460,7 @@ limitations under the License.</inlineHeader>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-plugin-plugin</artifactId>
-          <version>3.5</version>
+          <version>3.5.1</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/src/main/java/org/llorllale/mvn/plgn/loggit/Changelog.java
+++ b/src/main/java/org/llorllale/mvn/plgn/loggit/Changelog.java
@@ -45,14 +45,14 @@ public final class Changelog extends AbstractMojo {
   @Parameter(name = "repo", defaultValue = "${basedir}")
   private File repo;
 
-  @Parameter(name = "outputFile", defaultValue = "gitlog.xml")
-  private File xml;
+  @Parameter(name = "outputFile", defaultValue = "${project.build.directory}/gitlog.xml")
+  private File outputFile;
 
   @Parameter(name = "format", defaultValue = "default")
   private String format;
 
   @Parameter(name = "customFormatFile")
-  private File customFormat;
+  private File customFormatFile;
 
   @Parameter(name = "ref", defaultValue = Constants.MASTER)
   private String ref;
@@ -115,9 +115,9 @@ public final class Changelog extends AbstractMojo {
   @SuppressWarnings("checkstyle:ParameterNumber")
   public Changelog(File repo, File output, String format, File customFormat, String ref) {
     this.repo = repo;
-    this.xml = output;
+    this.outputFile = output;
     this.format = format;
-    this.customFormat = customFormat;
+    this.customFormatFile = customFormat;
     this.ref = ref;
   }
 
@@ -134,13 +134,13 @@ public final class Changelog extends AbstractMojo {
                 ).log().asXml()
               )
             ),
-            new OutputTo(this.xml)
+            new OutputTo(this.outputFile)
           )
         )
       ).value();
     } catch (IOException e) {
       throw new MojoFailureException(
-        String.format("Cannot save XML from repo %s to file %s", this.repo, this.xml),
+        String.format("Cannot save XML from repo %s to file %s", this.repo, this.outputFile),
         e
       );
     }
@@ -158,7 +158,7 @@ public final class Changelog extends AbstractMojo {
     if ("markdown".equals(this.format)) {
       output = new Markdown().applyTo(original);
     } else if ("custom".equals(this.format)) {
-      output = new Custom(new InputOf(this.customFormat)).applyTo(original);
+      output = new Custom(new InputOf(this.customFormatFile)).applyTo(original);
     } else {
       output = new Identity().applyTo(original);
     }


### PR DESCRIPTION
closes #65 

This PR:
* Matches the names of the attributes of mojo `Changelog` to their `@Parameter.name()`
* Bumps version of `maven-plugin-plugin` up to `3.5.1`
* Configures default value for `outputFile` to place file inside the build directory