### PR TITLE
(#69) Limit entries up until and including a given tag is found

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,13 @@
                 <goals>
                   <goal>jar</goal>
                 </goals>
+                <configuration>
+                  <tags>
+                    <tag>
+                      <name>todo</name>
+                    </tag>
+                  </tags>
+                </configuration>
               </execution>
             </executions>
           </plugin>
@@ -408,6 +415,11 @@
           <version>2.10.4</version>
           <configuration>
             <level>protected</level>
+            <tags>
+              <tag>
+                <name>todo</name>
+              </tag>
+            </tags>
           </configuration>
         </plugin>
         <plugin>

--- a/src/main/java/org/llorllale/mvn/plgn/loggit/Changelog.java
+++ b/src/main/java/org/llorllale/mvn/plgn/loggit/Changelog.java
@@ -40,6 +40,8 @@ import org.llorllale.mvn.plgn.loggit.xsl.pre.Limit;
  *
  * @author George Aristy (george.aristy@gmail.com)
  * @since 0.2.0
+ * @todo #60:30min Add new option to truncate the commits up to and including the tag provided by
+ *  the user. Use the new "commit/taggedAs/tag" structure for this.
  */
 @Mojo(name = "changelog")
 public final class Changelog extends AbstractMojo {

--- a/src/main/java/org/llorllale/mvn/plgn/loggit/DefaultCommit.java
+++ b/src/main/java/org/llorllale/mvn/plgn/loggit/DefaultCommit.java
@@ -19,6 +19,7 @@ package org.llorllale.mvn.plgn.loggit;
 import com.jcabi.xml.StrictXML;
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
+import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.xembly.Directives;
 import org.xembly.Xembler;
@@ -32,15 +33,18 @@ import org.xembly.Xembler;
  *  As it is, this class, and especially its mock counterpart, handle too many details.
  */
 final class DefaultCommit implements Commit {
+  private final Repository repo;
   private final RevCommit rev;
 
   /**
    * Ctor.
    * 
+   * @param repo the git repository
    * @param rev the git rev
-   * @since 0.1.0
+   * @since 0.5.0
    */
-  DefaultCommit(RevCommit rev) {
+  DefaultCommit(Repository repo, RevCommit rev) {
+    this.repo = repo;
     this.rev = rev;
   }
 
@@ -61,6 +65,8 @@ final class DefaultCommit implements Commit {
                 .add("short").set(this.rev.getShortMessage()).up()
                 .add("full").set(this.rev.getFullMessage()).up()
                 .up()
+              .add("taggedAs")
+              .append(new TagsOf(this.repo, this.rev))
         ).xmlQuietly()
       ),
       new Schema()

--- a/src/main/java/org/llorllale/mvn/plgn/loggit/DefaultLog.java
+++ b/src/main/java/org/llorllale/mvn/plgn/loggit/DefaultLog.java
@@ -61,7 +61,7 @@ final class DefaultLog implements Log {
         )
       );
       return new Mapped<>(
-        DefaultCommit::new,
+        commit -> new DefaultCommit(this.repo, commit),
         walk
       );
     } catch (NullPointerException e) {

--- a/src/main/java/org/llorllale/mvn/plgn/loggit/TagsOf.java
+++ b/src/main/java/org/llorllale/mvn/plgn/loggit/TagsOf.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018 George Aristy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.llorllale.mvn.plgn.loggit;
+
+import java.util.Iterator;
+import org.cactoos.iterable.Mapped;
+import org.cactoos.iterator.Filtered;
+import org.cactoos.scalar.And;
+import org.cactoos.scalar.UncheckedScalar;
+import org.eclipse.jgit.api.LogCommand;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.xembly.Directive;
+import org.xembly.Directives;
+
+/**
+ * All tags pointing to a given commit.
+ *
+ * @author George Aristy (george.aristy@gmail.com)
+ * @since 0.5.0
+ */
+final class TagsOf implements Iterable<Directive> {
+  private final Repository repo;
+  private final RevCommit commit;
+
+  /**
+   * Ctor.
+   * 
+   * @param repo the git repository
+   * @param commit the commit for which to fetch the tags
+   * @since 0.5.0
+   */
+  TagsOf(Repository repo, RevCommit commit) {
+    this.repo = repo;
+    this.commit = commit;
+  }
+
+  @Override
+  public Iterator<Directive> iterator() {
+    return new UncheckedScalar<>(
+      () -> {
+        final Directives dirs = new Directives();
+        final LogCommand log = new org.eclipse.jgit.api.Git(this.repo).log();
+        new And(
+          tag -> {
+            if (new Filtered<>(rev -> rev.equals(this.commit), log.call().iterator()).hasNext()) {
+              dirs.add("tag").set(tag.getName().split("/")[2]).up();
+            }
+            return true;
+          },
+          new Mapped<>(
+            peeled -> {
+              log.add(peeled.getPeeledObjectId());
+              return peeled;
+            },
+            new Mapped<>(
+              ref -> this.repo.peel(ref),
+              new org.eclipse.jgit.api.Git(this.repo).tagList().call()
+            )
+          )
+        ).value();
+        return dirs.iterator();
+      }
+    ).value();
+  }
+}

--- a/src/main/resources/xsd/schema.xsd
+++ b/src/main/resources/xsd/schema.xsd
@@ -42,6 +42,13 @@
             </xsd:sequence>
           </xsd:complexType>
         </xsd:element>
+        <xsd:element name="taggedAs">
+          <xsd:complexType>
+            <xsd:sequence>
+              <xsd:element name="tag" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+            </xsd:sequence>
+          </xsd:complexType>
+        </xsd:element>
       </xsd:sequence>
     </xsd:complexType>
   </xsd:element>

--- a/src/test/java/org/llorllale/mvn/plgn/loggit/DefaultCommitTest.java
+++ b/src/test/java/org/llorllale/mvn/plgn/loggit/DefaultCommitTest.java
@@ -51,7 +51,7 @@ public final class DefaultCommitTest {
       .setMessage("This is a test.\n\nTest of DefaultCommit.asXml")
       .call();
     assertThat(
-      new DefaultCommit(commit).asXml(),
+      new DefaultCommit(repo.getRepository(), commit).asXml(),
       allOf(
         hasXPath(String.format("/commit[id = '%s']", commit.getId().getName())),
         hasXPath(String.format("/commit/author[name = '%s']", commit.getAuthorIdent().getName())),

--- a/src/test/java/org/llorllale/mvn/plgn/loggit/TagsOfTest.java
+++ b/src/test/java/org/llorllale/mvn/plgn/loggit/TagsOfTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2018 George Aristy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.llorllale.mvn.plgn.loggit;
+
+// @checkstyle AvoidStaticImport (3 lines)
+import static com.jcabi.matchers.XhtmlMatchers.hasXPath;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.junit.Test;
+import org.xembly.Directives;
+import org.xembly.Xembler;
+
+/**
+ * Tests for {@link TagsOf}.
+ *
+ * @author George Aristy (george.aristy@gmail.com)
+ * @since 0.5.0
+ */
+@SuppressWarnings({"checkstyle:MethodName", "checkstyle:MultipleStringLiterals"})
+public final class TagsOfTest {
+  /**
+   * The short name of a tag pointing to a commit must be included in {@code commit/taggedAs/tag}.
+   * The "short name" is everything after the last forward slash in eg. {@code refs/tags/TAG}.
+   * 
+   * @throws Exception unexpected
+   * @since 0.5.0
+   */
+  @Test
+  public void includesTagsForAGivenCommit() throws Exception {
+    final org.eclipse.jgit.api.Git repo = this.repo();
+    final RevCommit first = this.addCommit(repo, "first", "first@gmail.com", "test");
+    final Ref tag = this.tag(repo, "v1.0");
+    final RevCommit second = this.addCommit(repo, "second", "second@gmail.com", "test");
+    assertThat(
+      new Xembler(
+        new Directives().add("taggedAs").append(new TagsOf(repo.getRepository(), first))
+      ).xml(),
+      hasXPath("/taggedAs/tag[. = 'v1.0']")
+    );
+  }
+
+  /**
+   * No tags added if the given commit was not tagged.
+   * 
+   * @throws Exception unexpected
+   * @since 0.5.0
+   */
+  @Test
+  public void noTagsIfGivenCommitWasNotTagged() throws Exception {
+    final org.eclipse.jgit.api.Git repo = this.repo();
+    final RevCommit first = this.addCommit(repo, "first", "first@gmail.com", "test");
+    final Ref tag = this.tag(repo, "v1.0");
+    final RevCommit second = this.addCommit(repo, "second", "second@gmail.com", "test");
+    assertThat(
+      new Xembler(
+        new Directives().add("taggedAs").append(new TagsOf(repo.getRepository(), second))
+      ).xml(),
+      not(hasXPath("/taggedAs[count(tag) > 0]"))
+    );   
+  }
+
+  /**
+   * No tags added when there are no tags. 
+   * 
+   * @throws Exception unexpected
+   * @since 0.5.0
+   */
+  @Test
+  public void emptyTags() throws Exception {
+    final org.eclipse.jgit.api.Git repo = this.repo();
+    final RevCommit first = this.addCommit(repo, "first", "first@gmail.com", "test");
+    final RevCommit second = this.addCommit(repo, "second", "second@gmail.com", "test");
+    assertThat(
+      new Xembler(
+        new Directives().add("taggedAs").append(new TagsOf(repo.getRepository(), second))
+      ).xml(),
+      not(hasXPath("/taggedAs[count(tag) > 0]"))
+    );
+  }
+
+  /**
+   * Initializes a git repo in a temp directory.
+   * 
+   * @return the repo
+   * @throws IOException unexpected
+   * @throws GitAPIException unexpected
+   */
+  private org.eclipse.jgit.api.Git repo() throws IOException, GitAPIException {
+    final File dir = Files.createTempDirectory("").toFile();
+    return org.eclipse.jgit.api.Git.init()
+      .setDirectory(dir)
+      .call();
+  }
+
+  /**
+   * Adds a commit to the repo.
+   * 
+   * @param repo the repo
+   * @param author the author name
+   * @param email the author email
+   * @param msg the commit msg
+   * @return the revcommit
+   * @throws GitAPIException unexpected
+   * @throws IOException unexpected
+   */
+  private RevCommit addCommit(
+    org.eclipse.jgit.api.Git repo, String author, String email, String msg
+  ) throws GitAPIException, IOException {
+    Files.createFile(
+      repo.getRepository().getWorkTree().toPath().resolve(System.nanoTime() + "test.txt")
+    );
+    repo.add().addFilepattern(".").call();
+    return repo.commit()
+      .setAuthor(author, email)
+      .setMessage(msg)
+      .call();
+  }
+
+  /**
+   * Tags the repo.
+   * 
+   * @param repo the repo to tag
+   * @param tag the tag's name
+   * @return the tag
+   * @throws GitAPIException unexpected
+   */
+  private Ref tag(org.eclipse.jgit.api.Git repo, String tag) throws GitAPIException {
+    return repo.tag().setName(tag).setMessage(tag).call();
+  }
+}


### PR DESCRIPTION
closes #69 

This PR:
* Adds new commit/taggedAs/tag structure to the schema
* New `TagsOf`: lists all tags pointing to a commit
* Leaves puzzle to finish implementing mojo parameter that takes in the tag name
* Leaves a puzzle to reduce complexity in a method