### PR TITLE
(#71) Add new option to truncate the commits up to and including the tag provided by the user

### DIFF
--- a/src/main/java/org/llorllale/mvn/plgn/loggit/Changelog.java
+++ b/src/main/java/org/llorllale/mvn/plgn/loggit/Changelog.java
@@ -34,6 +34,7 @@ import org.llorllale.mvn.plgn.loggit.xsl.post.Custom;
 import org.llorllale.mvn.plgn.loggit.xsl.post.Identity;
 import org.llorllale.mvn.plgn.loggit.xsl.post.Markdown;
 import org.llorllale.mvn.plgn.loggit.xsl.pre.Limit;
+import org.llorllale.mvn.plgn.loggit.xsl.pre.UntilTag;
 
 /**
  * Changelog.
@@ -62,6 +63,9 @@ public final class Changelog extends AbstractMojo {
 
   @Parameter(name = "maxEntries", defaultValue = "2147483647")
   private int maxEntries;
+
+  @Parameter(name = "endTag", defaultValue = "")
+  private String endTag;
 
   /**
    * Ctor.
@@ -139,12 +143,34 @@ public final class Changelog extends AbstractMojo {
     File repo, File output, String format,
     File customFormat, String ref, int maxEntries
   ) {
+    this(repo, output, format, customFormat, ref, maxEntries, "");
+  }
+
+  /**
+   * Ctor.
+   * 
+   * @param repo path to git repo
+   * @param output file to which to save the XML
+   * @param format the format for the output
+   * @param customFormat path to customFormat
+   * @param ref the ref to point to in order to fetch the log
+   * @param maxEntries max number of entries to include in the log
+   * @param endTag tag until which to include commits
+   * @since 0.4.0
+   */
+  @SuppressWarnings("checkstyle:ParameterNumber")
+  public Changelog(
+    File repo, File output, String format,
+    File customFormat, String ref, int maxEntries,
+    String endTag
+  ) {
     this.repo = repo;
     this.outputFile = output;
     this.format = format;
     this.customFormatFile = customFormat;
     this.ref = ref;
     this.maxEntries = maxEntries;
+    this.endTag = endTag;
   }
 
   @Override
@@ -201,6 +227,8 @@ public final class Changelog extends AbstractMojo {
    * @throws IOException if there's an error during the transformation
    */
   private XML preprocess(XML xml) throws IOException {
-    return new Limit(this.maxEntries).transform(xml);
+    return new UntilTag(this.endTag).transform(
+      new Limit(this.maxEntries).transform(xml)
+    );
   }
 }

--- a/src/main/java/org/llorllale/mvn/plgn/loggit/xsl/pre/UntilTag.java
+++ b/src/main/java/org/llorllale/mvn/plgn/loggit/xsl/pre/UntilTag.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 George Aristy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.llorllale.mvn.plgn.loggit.xsl.pre;
+
+import org.cactoos.io.ResourceOf;
+import org.cactoos.map.MapEntry;
+import org.cactoos.map.MapOf;
+import org.llorllale.mvn.plgn.loggit.xsl.StylesheetEnvelope;
+
+/**
+ * Copies commits until one with a given tag is found.
+ *
+ * @author George Aristy (george.aristy@gmail.com)
+ * @since 0.5.0
+ */
+public final class UntilTag extends StylesheetEnvelope {
+  /**
+   * Ctor.
+   * 
+   * @param tag the tag upon which to stop copying the commits
+   * @since 0.5.0
+   */
+  public UntilTag(String tag) {
+    super(
+      new ResourceOf("xsl/pre/until-tag.xsl"),
+      new MapOf<>(new MapEntry<>("tag", tag))
+    );
+  }
+}

--- a/src/main/resources/xsl/pre/until-tag.xsl
+++ b/src/main/resources/xsl/pre/until-tag.xsl
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<!--
+
+    Copyright 2018 George Aristy
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+  <xsl:param name="tag"/>
+  <xsl:variable name="end" select="string(//commit[taggedAs/tag = $tag]/id[last()])"/>
+  <xsl:template match="commits">
+    <commits>
+      <xsl:call-template name="loop">
+        <xsl:with-param name="commits" select="//commit"/>
+      </xsl:call-template>
+    </commits>
+  </xsl:template>
+  <xsl:template name="loop">
+    <xsl:param name="commits"/>
+    <xsl:if test="count($commits) > 0">
+      <xsl:variable name="commit" select="$commits[1]"/>
+      <xsl:if test="$commit/id != $end">
+        <xsl:copy-of select="$commit"/>
+        <xsl:call-template name="loop">
+          <xsl:with-param name="commits" select="$commit/following-sibling::commit"/>
+        </xsl:call-template>
+      </xsl:if>
+    </xsl:if>
+  </xsl:template>
+  <xsl:template match="node()|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+    </xsl:copy>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/test/java/org/llorllale/mvn/plgn/loggit/xsl/pre/UntilTagTest.java
+++ b/src/test/java/org/llorllale/mvn/plgn/loggit/xsl/pre/UntilTagTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2018 George Aristy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.llorllale.mvn.plgn.loggit.xsl.pre;
+
+// @checkstyle AvoidStaticImport (5 lines)
+import static com.jcabi.matchers.XhtmlMatchers.hasXPath;
+import static com.jcabi.matchers.XhtmlMatchers.hasXPaths;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+
+import com.jcabi.xml.XMLDocument;
+import org.junit.Test;
+
+/**
+ * Tests for {@link UntilTag}.
+ *
+ * @author George Aristy (george.aristy@gmail.com)
+ * @since 0.5.0
+ * @checkstyle MethodName (500 lines)
+ */
+@SuppressWarnings("checkstyle:MultipleStringLiterals")
+public final class UntilTagTest {
+  private static final String LOG =
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+    + "<log>"
+    + "  <commits>"
+    + "    <commit>"
+    + "      <id>b8ed3b6449289df8f5c9196492idj85613cefe96</id>"
+    + "      <author>"
+    + "        <name>fourth</name>"
+    + "        <email>fourth@test.com</email>"
+    + "        <date>2018-02-26T16:42:00Z</date>"
+    + "      </author>"
+    + "      <message>"
+    + "        <short>Fourth commit</short>"
+    + "        <full>Fourth commit</full>"
+    + "      </message>"
+    + "      <taggedAs/>"
+    + "    </commit>"
+    + "    <commit>"
+    + "      <id>b8ed3b6449289df8f5c9196489dce85613cefe96</id>"
+    + "      <author>"
+    + "        <name>third</name>"
+    + "        <email>third@test.com</email>"
+    + "        <date>2018-02-26T16:42:00Z</date>"
+    + "      </author>"
+    + "      <message>"
+    + "        <short>Third commit</short>"
+    + "        <full>Third commit</full>"
+    + "      </message>"
+    + "      <taggedAs/>"
+    + "    </commit>"
+    + "    <commit>"
+    + "      <id>fcc814a658aea3537ad5182ff211ed8c58479fb9</id>"
+    + "      <author>"
+    + "        <name>second</name>"
+    + "        <email>second@test.com</email>"
+    + "        <date>2018-02-26T16:42:00Z</date>"
+    + "      </author>"
+    + "      <message>"
+    + "        <short>Second commit</short>"
+    + "        <full>Second commit</full>"
+    + "      </message>"
+    + "      <taggedAs>"
+    + "        <tag>1.0.0</tag>"
+    + "      </taggedAs>"
+    + "    </commit>"
+    + "    <commit>"
+    + "      <id>b8ed3b64435525f8f5c9196489dce85613cefe96</id>"
+    + "      <author>"
+    + "        <name>first</name>"
+    + "        <email>first@test.com</email>"
+    + "        <date>2018-02-26T16:42:00Z</date>"
+    + "      </author>"
+    + "      <message>"
+    + "        <short>First commit</short>"
+    + "        <full>First commit</full>"
+    + "      </message>"
+    + "      <taggedAs/>"
+    + "    </commit>"
+    + "  </commits>"
+    + "</log>";
+
+  /**
+   * No commit should be excluded if no tag/empty tag is specified.
+   * 
+   * @since 0.5.0
+   */
+  @Test
+  public void allCommitsIncludedIfNoTagIsGiven() {
+    assertThat(
+      new UntilTag("").applyTo(new XMLDocument(UntilTagTest.LOG)),
+      hasXPaths(
+        "/log/commits/commit[id = 'b8ed3b6449289df8f5c9196492idj85613cefe96']",
+        "/log/commits/commit[id = 'b8ed3b6449289df8f5c9196489dce85613cefe96']",
+        "/log/commits/commit[id = 'fcc814a658aea3537ad5182ff211ed8c58479fb9']",
+        "/log/commits/commit[id = 'b8ed3b64435525f8f5c9196489dce85613cefe96']"
+      )
+    );
+  }
+
+  /**
+   * Do not include commits starting from the one with the given tag.
+   * 
+   * @since 0.5.0
+   */
+  @Test
+  public void truncateCommitsStartingFromTag() {
+    assertThat(
+      new UntilTag("1.0.0").applyTo(new XMLDocument(UntilTagTest.LOG)),
+      allOf(
+        hasXPath("/log/commits/commit[id = 'b8ed3b6449289df8f5c9196492idj85613cefe96']"),
+        hasXPath("/log/commits/commit[id = 'b8ed3b6449289df8f5c9196489dce85613cefe96']"),
+        not(hasXPath("/log/commits/commit[id = 'fcc814a658aea3537ad5182ff211ed8c58479fb9']")),
+        not(hasXPath("/log/commits/commit[id = 'b8ed3b64435525f8f5c9196489dce85613cefe96']"))
+      )
+    );
+  }
+}


### PR DESCRIPTION
closes #71 

This PR provides:

* New option 'endTag' with default value "". Commits are excluded starting from the first one encountered with the given tag
* New preprocessor 'UntilTag' that performs the above