### PR TITLE
(#74) Add option to filter commits by their message

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -58,6 +58,7 @@ This project includes:
   Plexus :: Component Annotations under The Apache Software License, Version 2.0
   Plexus Classworlds under The Apache Software License, Version 2.0
   Plexus Common Utilities under Apache License, Version 2.0
+  Saxon-HE under Mozilla Public License Version 2.0
   SLF4J API Module under MIT License
   TXW2 Runtime under CDDL+GPL License
   xembly under BSD

--- a/pom.xml
+++ b/pom.xml
@@ -258,6 +258,11 @@
       <version>0.21.1</version>
     </dependency>
     <dependency>
+      <groupId>net.sf.saxon</groupId>
+      <artifactId>Saxon-HE</artifactId>
+      <version>9.8.0-5</version>
+    </dependency>
+    <dependency>
       <groupId>com.jcabi.incubator</groupId>
       <artifactId>xembly</artifactId>
       <version>0.22</version>

--- a/src/main/java/org/llorllale/mvn/plgn/loggit/Changelog.java
+++ b/src/main/java/org/llorllale/mvn/plgn/loggit/Changelog.java
@@ -34,6 +34,7 @@ import org.llorllale.mvn.plgn.loggit.xsl.post.Custom;
 import org.llorllale.mvn.plgn.loggit.xsl.post.Identity;
 import org.llorllale.mvn.plgn.loggit.xsl.post.Markdown;
 import org.llorllale.mvn.plgn.loggit.xsl.pre.Limit;
+import org.llorllale.mvn.plgn.loggit.xsl.pre.Pattern;
 import org.llorllale.mvn.plgn.loggit.xsl.pre.UntilTag;
 
 /**
@@ -64,6 +65,9 @@ public final class Changelog extends AbstractMojo {
 
   @Parameter(name = "endTag", defaultValue = "")
   private String endTag;
+
+  @Parameter(name = "includeRegex", defaultValue = ".*")
+  private String includeRegex;
 
   /**
    * Ctor.
@@ -154,13 +158,35 @@ public final class Changelog extends AbstractMojo {
    * @param ref the ref to point to in order to fetch the log
    * @param maxEntries max number of entries to include in the log
    * @param endTag tag until which to include commits
-   * @since 0.4.0
+   * @since 0.5.0
    */
   @SuppressWarnings("checkstyle:ParameterNumber")
   public Changelog(
     File repo, File output, String format,
     File customFormat, String ref, int maxEntries,
     String endTag
+  ) {
+    this(repo, output, format, customFormat, ref, maxEntries, endTag, ".*");
+  }
+
+  /**
+   * Ctor.
+   * 
+   * @param repo path to git repo
+   * @param output file to which to save the XML
+   * @param format the format for the output
+   * @param customFormat path to customFormat
+   * @param ref the ref to point to in order to fetch the log
+   * @param maxEntries max number of entries to include in the log
+   * @param endTag tag until which to include commits
+   * @param includeRegex the regular expression that commit messages must match
+   * @since 0.6.0
+   */
+  @SuppressWarnings("checkstyle:ParameterNumber")
+  public Changelog(
+    File repo, File output, String format,
+    File customFormat, String ref, int maxEntries,
+    String endTag, String includeRegex
   ) {
     this.repo = repo;
     this.outputFile = output;
@@ -169,6 +195,7 @@ public final class Changelog extends AbstractMojo {
     this.ref = ref;
     this.maxEntries = maxEntries;
     this.endTag = endTag;
+    this.includeRegex = includeRegex;
   }
 
   @Override
@@ -225,8 +252,10 @@ public final class Changelog extends AbstractMojo {
    * @throws IOException if there's an error during the transformation
    */
   private XML preprocess(XML xml) throws IOException {
-    return new UntilTag(this.endTag).transform(
-      new Limit(this.maxEntries).transform(xml)
+    return new Pattern(this.includeRegex).transform(
+      new UntilTag(this.endTag).transform(
+        new Limit(this.maxEntries).transform(xml)
+      )
     );
   }
 }

--- a/src/main/java/org/llorllale/mvn/plgn/loggit/xsl/pre/Pattern.java
+++ b/src/main/java/org/llorllale/mvn/plgn/loggit/xsl/pre/Pattern.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 George Aristy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.llorllale.mvn.plgn.loggit.xsl.pre;
+
+import org.cactoos.io.ResourceOf;
+import org.cactoos.map.MapEntry;
+import org.cactoos.map.MapOf;
+import org.llorllale.mvn.plgn.loggit.xsl.StylesheetEnvelope;
+
+/**
+ * Includes commits with messages that match a given regular expression.
+ *
+ * @author George Aristy (george.aristy@gmail.com)
+ * @since 0.6.0
+ */
+public final class Pattern extends StylesheetEnvelope {
+  /**
+   * Ctor.
+   * 
+   * @param regex the regular expression
+   * @since 0.6.0
+   */
+  public Pattern(String regex) {
+    super(
+      new ResourceOf("xsl/pre/pattern.xsl"),
+      new MapOf<>(new MapEntry<>("regex", regex))
+    );
+  }
+}

--- a/src/main/resources/xsl/pre/pattern.xsl
+++ b/src/main/resources/xsl/pre/pattern.xsl
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<!--
+
+    Copyright 2018 George Aristy
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
+  <xsl:param name="regex"/>
+  <xsl:template match="commits">
+    <commits>
+      <xsl:for-each select="commit">
+        <xsl:if test="matches(message/full, $regex)">
+          <xsl:copy-of select="."/>
+        </xsl:if>
+      </xsl:for-each>
+    </commits>
+  </xsl:template>
+  <xsl:template match="node()|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+    </xsl:copy>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/test/java/org/llorllale/mvn/plgn/loggit/xsl/pre/PatternTest.java
+++ b/src/test/java/org/llorllale/mvn/plgn/loggit/xsl/pre/PatternTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2018 George Aristy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.llorllale.mvn.plgn.loggit.xsl.pre;
+
+// @checkstyle AvoidStaticImport (4 lines)
+import static com.jcabi.matchers.XhtmlMatchers.hasXPath;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+
+import com.jcabi.xml.StrictXML;
+import com.jcabi.xml.XMLDocument;
+import org.junit.Test;
+import org.llorllale.mvn.plgn.loggit.Schema;
+
+/**
+ * Tests for {@link Pattern}.
+ *
+ * @author George Aristy (george.aristy@gmail.com)
+ * @since 0.6.0
+ * @checkstyle MethodName (500 lines)
+ */
+@SuppressWarnings("checkstyle:MultipleStringLiterals")
+public final class PatternTest {
+  private static final String LOG =
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+    + "<log>"
+    + "  <commits>"
+    + "    <commit>"
+    + "      <id>fcc814a658aea3537ad5182ff211ed8c58479fb9</id>"
+    + "      <author>"
+    + "        <name>second</name>"
+    + "        <email>second@test.com</email>"
+    + "        <date>2018-02-26T16:42:00Z</date>"
+    + "      </author>"
+    + "      <message>"
+    + "        <short>Second commit</short>"
+    + "        <full>Second commit</full>"
+    + "      </message>"
+    + "      <taggedAs/>"
+    + "    </commit>"
+    + "    <commit>"
+    + "      <id>b8ed3b64435525f8f5c9196489dce85613cefe96</id>"
+    + "      <author>"
+    + "        <name>first</name>"
+    + "        <email>first@test.com</email>"
+    + "        <date>2018-02-26T16:42:00Z</date>"
+    + "      </author>"
+    + "      <message>"
+    + "        <short>First commit</short>"
+    + "        <full>First commit</full>"
+    + "      </message>"
+    + "      <taggedAs/>"
+    + "    </commit>"
+    + "  </commits>"
+    + "</log>";
+
+  /**
+   * Includes only commits with message that matches the given regex.
+   * 
+   * @since 0.6.0
+   */
+  @Test
+  public void includeOnlyCommitsWithRegex() {
+    assertThat(
+      new Pattern("First.*").transform(new XMLDocument(PatternTest.LOG)),
+      allOf(
+        hasXPath("/log/commits/commit[id = 'b8ed3b64435525f8f5c9196489dce85613cefe96']"),
+        not(hasXPath("/log/commits/commit[id = 'fcc814a658aea3537ad5182ff211ed8c58479fb9']"))
+      )
+    );
+  }
+
+  /**
+   * No commits should be excluded if we pass '.*'.
+   * 
+   * @since 0.6.0
+   */
+  @Test
+  public void includeAllCommitsWithDefaultRegex() {
+    assertThat(
+      new Pattern(".*").transform(new XMLDocument(PatternTest.LOG)),
+      allOf(
+        hasXPath("/log/commits/commit[id = 'b8ed3b64435525f8f5c9196489dce85613cefe96']"),
+        hasXPath("/log/commits/commit[id = 'fcc814a658aea3537ad5182ff211ed8c58479fb9']")
+      )   
+    );
+  }
+
+  /**
+   * Output XML must be valid against the schema.
+   * 
+   * @since 0.6.0
+   */
+  @Test
+  public void validateXml() {
+    new StrictXML(
+      new Pattern(".*").transform(new XMLDocument(PatternTest.LOG)),
+      new Schema()
+    ).toString();
+  }
+}


### PR DESCRIPTION
This PR:

* closes #74 
* Added `Pattern` preprocessor that includes commits for which their `<full>` message matches a given regex
* Added net.sf.saxon:Saxon-HE as dependency otherwise xpath function 'matches' wouldn't work
* Updated NOTICE due to the previous point