### PR TITLE
(#89) Plugin runtime error

### DIFF
--- a/src/main/java/org/llorllale/mvn/plgn/loggit/Changelog.java
+++ b/src/main/java/org/llorllale/mvn/plgn/loggit/Changelog.java
@@ -19,6 +19,7 @@ package org.llorllale.mvn.plgn.loggit;
 import com.jcabi.xml.XML;
 import java.io.File;
 import java.io.IOException;
+import java.util.Optional;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -291,8 +292,8 @@ public final class Changelog extends AbstractMojo {
    */
   private XML preprocess(XML xml) throws IOException {
     return new Pattern(this.includeRegex).transform(
-      new EndTag(this.endTag).transform(
-        new StartTag(this.startTag).transform(
+      new EndTag(Optional.ofNullable(this.endTag).orElse("")).transform(
+        new StartTag(Optional.ofNullable(this.startTag).orElse("")).transform(
           new Limit(this.maxEntries).transform(xml)
         )
       )


### PR DESCRIPTION
This PR:
* closes #89 
* TagsOf.java: substituted use of the porcelain API for RevWalk
* Fixes these bugs that cropped up after fixing the above:
   * BUG: error indicating "null parameter"
      Maven will not inject the empty string as a value for maven properties.
      This affected startTag and endTag since their defaults were "".
      See https://stackoverflow.com/questions/15558723/empty-maven-mojo-parameter-instead-of-null and https://mail-archives.apache.org/mod_mbox/maven-users/200901.mbox/%3C534292.86670.qm@web51406.mail.re2.yahoo.com%3E
    * BUG: multiple commits were being given the same tag