### PR TITLE
(#91) Regex flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ They are also available from the command line if you prefix them with `loggit.` 
           <startTag></startTag> <!-- empty -->
           <endTag></endTag> <!-- empty -->
           <includeRegex>.*</includeRegex>
+          <includeRegexFlags></includeRegexFlags> <!-- empty -->
         </configuration>
       </plugin>
       ...
@@ -66,6 +67,7 @@ They are also available from the command line if you prefix them with `loggit.` 
 * `<startTag>`: if specified, will truncate the log starting at the commit with the given tag
 * `<endTag>`: if specified, will exclude all commits that appear *before* a commit with the given tag
 * `<includeRegex>`: includes only commits with messages that match the given regular expression
+* `<includeRegexFlags>`: flags for the regex engine. Supported values can be found [here](https://www.w3.org/TR/xpath-functions-30/#flags)
 
 ## How it works
 
@@ -74,7 +76,7 @@ They are also available from the command line if you prefix them with `loggit.` 
 In three stages:
 
 1. The git log is read and the XML is built (relevant configs: `<repo>`, `<branch>`)
-2. The XML is pre-processed for common use cases (relevant configs: `<maxEntries>`, `<startTag>`, `<endTag>`, `<includeRegex>`)
+2. The XML is pre-processed for common use cases (relevant configs: `<maxEntries>`, `<startTag>`, `<endTag>`, `<includeRegex>`, `<includeRegexFlags>`)
 3. The XML is post-processed using XSLT and the result is written to file (relevant configs: `<format>`, `<customFileFormat>`, `<outputFile>`)
 
 ## Examples

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
   <groupId>org.llorllale</groupId>
   <artifactId>loggit-maven-plugin</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.1-SNAPSHOT</version>
 
   <packaging>maven-plugin</packaging>
 

--- a/src/main/java/org/llorllale/mvn/plgn/loggit/Changelog.java
+++ b/src/main/java/org/llorllale/mvn/plgn/loggit/Changelog.java
@@ -80,6 +80,9 @@ public final class Changelog extends AbstractMojo {
   @Parameter(name = "includeRegex", defaultValue = ".*", property = "loggit.includeRegex")
   private String includeRegex;
 
+  @Parameter(name = "includeRegexFlags", defaultValue = "", property = "loggit.includeRegexFlags")
+  private String includeRegexFlags = "";
+
   /**
    * Ctor.
    * 
@@ -291,7 +294,7 @@ public final class Changelog extends AbstractMojo {
    * @throws IOException if there's an error during the transformation
    */
   private XML preprocess(XML xml) throws IOException {
-    return new Pattern(this.includeRegex).transform(
+    return new Pattern(this.includeRegex, this.includeRegexFlags).transform(
       new EndTag(Optional.ofNullable(this.endTag).orElse("")).transform(
         new StartTag(Optional.ofNullable(this.startTag).orElse("")).transform(
           new Limit(this.maxEntries).transform(xml)

--- a/src/main/java/org/llorllale/mvn/plgn/loggit/xsl/pre/Pattern.java
+++ b/src/main/java/org/llorllale/mvn/plgn/loggit/xsl/pre/Pattern.java
@@ -25,6 +25,8 @@ import org.llorllale.mvn.plgn.loggit.xsl.StylesheetEnvelope;
  * Includes commits with messages that match a given regular expression.
  *
  * @author George Aristy (george.aristy@gmail.com)
+ * @see <a href="https://www.w3.org/TR/xpath-functions-30/#func-matches">fn:matches</a>
+ * @see <a href="https://www.w3.org/TR/xpath-functions-30/#flags">Flags</a>
  * @since 0.6.0
  */
 public final class Pattern extends StylesheetEnvelope {
@@ -32,12 +34,16 @@ public final class Pattern extends StylesheetEnvelope {
    * Ctor.
    * 
    * @param regex the regular expression
+   * @param flags regex flags
    * @since 0.6.0
    */
-  public Pattern(String regex) {
+  public Pattern(String regex, String flags) {
     super(
       new ResourceOf("xsl/pre/pattern.xsl"),
-      new MapOf<>(new MapEntry<>("regex", regex))
+      new MapOf<>(
+          new MapEntry<>("regex", regex),
+          new MapEntry<>("flags", flags)
+      )
     );
   }
 }

--- a/src/main/resources/xsl/pre/pattern.xsl
+++ b/src/main/resources/xsl/pre/pattern.xsl
@@ -18,10 +18,11 @@
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3.0">
   <xsl:param name="regex"/>
+  <xsl:param name="flags"/>
   <xsl:template match="commits">
     <commits>
       <xsl:for-each select="commit">
-        <xsl:if test="matches(message/full, $regex)">
+        <xsl:if test="matches(message/full, $regex, $flags)">
           <xsl:copy-of select="."/>
         </xsl:if>
       </xsl:for-each>

--- a/src/site/markdown/index.md.vm
+++ b/src/site/markdown/index.md.vm
@@ -70,6 +70,7 @@ They are also available from the command line if you prefix them with `loggit.` 
             <startTag></startTag> <!-- empty -->
             <endTag></endTag> <!-- empty -->
             <includeRegex>.*</includeRegex>
+            <includeRegexFlags></includeRegexFlags> <!-- empty -->
           </configuration>
         </plugin>
         ...
@@ -87,6 +88,7 @@ $h3 Configuration
 * `<startTag>`: if specified, will truncate the log starting at the commit with the given tag
 * `<endTag>`: if specified, will exclude all commits that appear *before* a commit with the given tag
 * `<includeRegex>`: includes only commits with messages that match the given regular expression
+* `<includeRegexFlags>`: flags for the regex engine. Supported values can be found [here](https://www.w3.org/TR/xpath-functions-30/#flags)
 
 $h2 How it works
 
@@ -95,7 +97,7 @@ $h2 How it works
 In three stages:
 
 1. The git log is read and the XML is built (relevant configs: `<repo>`, `<branch>`)
-2. The XML is pre-processed for common use cases (relevant configs: `<maxEntries>`, `<startTag>`, `<endTag>`, `<includeRegex>`)
+2. The XML is pre-processed for common use cases (relevant configs: `<maxEntries>`, `<startTag>`, `<endTag>`, `<includeRegex>`, `<includeRegexFlags>`)
 3. The XML is post-processed using XSLT and the result is written to file (relevant configs: `<format>`, `<customFileFormat>`, `<outputFile>`)
 
 $h2 Examples

--- a/src/test/java/org/llorllale/mvn/plgn/loggit/xsl/pre/PatternTest.java
+++ b/src/test/java/org/llorllale/mvn/plgn/loggit/xsl/pre/PatternTest.java
@@ -77,7 +77,7 @@ public final class PatternTest {
   @Test
   public void includeOnlyCommitsWithRegex() {
     assertThat(
-      new Pattern("First.*").transform(new XMLDocument(PatternTest.LOG)),
+      new Pattern("First.*", "").transform(new XMLDocument(PatternTest.LOG)),
       allOf(
         hasXPath("/log/commits/commit[id = 'b8ed3b64435525f8f5c9196489dce85613cefe96']"),
         not(hasXPath("/log/commits/commit[id = 'fcc814a658aea3537ad5182ff211ed8c58479fb9']"))
@@ -93,7 +93,7 @@ public final class PatternTest {
   @Test
   public void includeAllCommitsWithDefaultRegex() {
     assertThat(
-      new Pattern(".*").transform(new XMLDocument(PatternTest.LOG)),
+      new Pattern(".*", "").transform(new XMLDocument(PatternTest.LOG)),
       allOf(
         hasXPath("/log/commits/commit[id = 'b8ed3b64435525f8f5c9196489dce85613cefe96']"),
         hasXPath("/log/commits/commit[id = 'fcc814a658aea3537ad5182ff211ed8c58479fb9']")
@@ -109,8 +109,24 @@ public final class PatternTest {
   @Test
   public void validateXml() {
     new StrictXML(
-      new Pattern(".*").transform(new XMLDocument(PatternTest.LOG)),
+      new Pattern(".*", "").transform(new XMLDocument(PatternTest.LOG)),
       new Schema()
     ).toString();
+  }
+
+  /**
+   * Includes only commits that match the regex by ignoring case.
+   * 
+   * @since 1.0.1
+   */
+  @Test
+  public void caseInsensitiveRegex() {
+    assertThat(
+      new Pattern("second commit", "i").transform(new XMLDocument(PatternTest.LOG)),
+      allOf(
+        hasXPath("/log/commits/commit[id = 'fcc814a658aea3537ad5182ff211ed8c58479fb9']"),
+        not(hasXPath("/log/commits/commit[id = 'b8ed3b64435525f8f5c9196489dce85613cefe96']"))
+      )
+    );
   }
 }


### PR DESCRIPTION
This PR is for #91 and adds new `<includeRegexFlags>` parameter for regex flags.

See [fn:matches](https://www.w3.org/TR/xpath-functions-30/#func-matches) and [Flags](https://www.w3.org/TR/xpath-functions-30/#flags).